### PR TITLE
Fix to avoid the dist/esm import

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "capacitor-get-latest-photo",
   "version": "0.0.5",
   "description": "Grabs the latest photo from the camera roll",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rm -rf ./dist",


### PR DESCRIPTION
As commented on your blog post, new plugins will have this path to avoid the need of the /dist/esm/ in the import. But old plugins need to be patched like this